### PR TITLE
test: use npm's built-in node-gyp in the tests

### DIFF
--- a/spec/install-spec.coffee
+++ b/spec/install-spec.coffee
@@ -538,7 +538,7 @@ describe 'apm install', ->
       beforeEach ->
         # Normally npm_config_node_gyp would be ignored, but it works here because we're calling apm
         # directly and not through the scripts in bin/
-        nodeGypPath = path.join(nodeModules, 'npm', 'node_modules', 'node-gyp')
+        nodeGypPath =  path.dirname(path.dirname(require.resolve('node-gyp'))) # find an installed node-gyp
         fs.copySync nodeGypPath, path.join(nodeModules, 'with a space')
         process.env.npm_config_node_gyp = path.join(nodeModules, 'with a space', 'bin', 'node-gyp.js')
 


### PR DESCRIPTION
### Description of the change

This uses npm's built-in node-gyp which is used in the tests. The tests assume that node-gyp should exist in node_modules, but this is an assumption about the test environment which may not be true. npm may not hoist `node-gyp` which is a dependency of the `npm` to the top-level `node-modules`.

https://github.com/atom-ide-community/apm/blob/475d35f92b0e257bb0c3fdbdb8e302ee8fb0d2bb/spec/install-spec.coffee#L536-L541

### Verification 
The tests now pass correctly. 

### Drawbacks
none

### Release Notes
N/A

Closes #10 