### PR TITLE
Respect the "NO_APM_DEDUPE" env var on Windows (affects the postinstall script)

### DIFF
--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -14,6 +14,11 @@ setx JOBS 16
 
 call .\bin\npm.cmd rebuild
 
-echo.
-echo ^>^> Deduping apm dependencies
-call .\bin\npm.cmd dedupe
+if defined NO_APM_DEDUPE (
+    echo.
+    echo ^>^> Deduplication disabled
+) else (
+    echo.
+    echo ^>^> Deduping apm dependencies
+    call .\bin\npm.cmd dedupe
+)

--- a/script/postinstall.cmd
+++ b/script/postinstall.cmd
@@ -9,7 +9,7 @@ echo.
 for /f "delims=" %%i in ('.\bin\node.exe -p "process.version + ' ' + process.arch"') do set bundledVersion=%%i
 echo ^>^> Rebuilding apm dependencies with bundled Node !bundledVersion!
 
-# parallel node-gyp
+:: parallel node-gyp
 setx JOBS 16
 
 call .\bin\npm.cmd rebuild


### PR DESCRIPTION
### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

Linux and macOS have respected a `NO_APM_DEDUPE` env var for a long time. If this env var is set, the postinstall script skips deduping (for these OSes, this is handled in `script/postinstall.sh`).

This PR adds a couple of lines to the Windows-specific `script\postinstall.cmd` file to do the same thing on Windows.

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

None.

### Benefits

<!-- What benefits will be realized by the code change? -->

This should enable installing `apm` with `npm ci --global-style` in Atom's `script/bootstrap`.

Which in turn means we can have reliable, stable bootstrapping, when desired, for the Atom repo.

~~That turned out not to be true. So, there is very little benefit. At least an env var that works on Linux and macOS will work on Windows with this PR merged. But there is little difference when installing apm with or without deduping.~~

Update: This _does_ work, in fact, in the usual use-case. Just not when specifying `apm` as a git URL dependency.

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

None.

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

For this repository on its own:

I ran `npm run postinstall` and `npm install` with this env var set (`set NO_APM_DEDUPE=true` in `cmd.exe`).

Deduping was successfully skipped, and a message was printed out (`>> Deduplication disabled`) to indicate that this is happening on purpose.

---

I also tested installing `apm` in Atom with `npm ci` like this:
- `cd atom\apm`
- Set `NO_APM_DEDUPE=true`
- `npm ci`
- _During `npm ci`, quickly after `apm` is extracted, copy over the modified `script\postinstall.cmd` and overwrite the existing, non-patched one. We want to patch `script\postinstall.cmd` in a stable version of `apm`._
  - If you are not on Windows, then there is no need to copy or patch any files. The flag is already respected on Linux/macOS.
- Observe that the following is printed at the end: `>> Deduplication disabled`
- Run `npm ls`, and observe that no packages are reported missing.

_(Live-patching this file will no-longer be needed once this PR is merged and shipped in a stable release of `apm`.)_

### Applicable Issues

<!-- Enter any applicable Issues here -->

None.