### PR TITLE
fix: bump git-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1072,19 +1072,12 @@
       }
     },
     "git-utils": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.6.2.tgz",
-      "integrity": "sha512-3pen//xGs5ZJiXejUbx79FyRR58J6DgI7tL9Mc7YQeuF5ENXf/7k0K2M8h4JBlTKZcxxCr8MGA1Xcg4O4l/YjA==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/git-utils/-/git-utils-5.7.1.tgz",
+      "integrity": "sha512-+mWdJDq9emWoq6GzzrGEB7SIBmAk0lNNv2wgNkgwTVZUkAFkWvgRsJ+Kvs3d1QQD6WG6vczti2WLpjmh2Twtlw==",
       "requires": {
         "fs-plus": "^3.0.0",
         "nan": "^2.14.0"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
-        }
       }
     },
     "github-from-package": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "colors": "~1.4.0",
     "first-mate": "^7.4.1",
     "fs-plus": "3.x",
-    "git-utils": "^5.6.2",
+    "git-utils": "^5.7.1",
     "glob": "^7.1.6",
     "hosted-git-info": "^3.0.7",
     "keytar": "^6.0.1",


### PR DESCRIPTION
### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
Bumps [git-utils](https://github.com/atom/git-utils) from 5.6.2 to 5.7.1.


### Benefits
Fixes Atom not being bootstrapped.

<!-- What benefits will be realized by the code change? -->



### Verification Process
The CI passes now.

### Applicable Issues
