### PR TITLE
Remove the dependency on npm APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,13 +59,13 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "integrity": "sha512-S2Hw0TtNkMJhIabBwIojKL9YHO5T0n5eNqWJ7Lrlel/zDbftQpxpapi8tZs3X1HWa+u+QeydGmzzNU0m09+Rcg==",
       "dev": true
     },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA=="
     },
     "aproba": {
       "version": "1.2.0",
@@ -113,13 +113,13 @@
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "dev": true
     },
     "asar": {
       "version": "0.12.1",
       "resolved": "https://registry.npmjs.org/asar/-/asar-0.12.1.tgz",
-      "integrity": "sha1-35Q+jrXNdPvKBmPi10uPK3J7UI8=",
+      "integrity": "sha512-lmgqdFF9XvKVQcrJ0mv2XxiStH1L0Tmh9G4eY2/XiNN3X25BrkFR/QuOK9ZZlhEWoqd9LiYtD/fe7+gvPcVvWA==",
       "requires": {
         "chromium-pickle-js": "^0.1.0",
         "commander": "^2.9.0",
@@ -134,7 +134,7 @@
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -148,7 +148,7 @@
     "asar-require": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/asar-require/-/asar-require-0.3.0.tgz",
-      "integrity": "sha1-R+TLRBSJSthplTbNDFjAySFRtFs=",
+      "integrity": "sha512-KqVbqfVhY+88TlLLh8wvZozZ5LI5sTCClS3Ik15XSgNGCLyW3u/qxnudh3Olj569fhixIcbbpQQoYKfthjQC0Q==",
       "requires": {
         "asar": "0.12.1"
       }
@@ -164,7 +164,7 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw=="
     },
     "async": {
       "version": "3.2.0",
@@ -174,12 +174,12 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA=="
     },
     "aws4": {
       "version": "1.11.0",
@@ -199,7 +199,7 @@
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
       "requires": {
         "tweetnacl": "^0.14.3"
       }
@@ -207,7 +207,7 @@
     "binary": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/binary/-/binary-0.3.0.tgz",
-      "integrity": "sha1-n2BVO8XOjDOG87VTz/R0Yq3sqnk=",
+      "integrity": "sha512-D4H1y5KYwpJgK8wk1Cue5LLPgmwHKYSChkbspQg5JtVuR5ulGckxfR62H3AE9UDkdMC8yyXlqYihuz3Aqg2XZg==",
       "requires": {
         "buffers": "~0.1.1",
         "chainsaw": "~0.1.0"
@@ -300,7 +300,7 @@
     "buffers": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/buffers/-/buffers-0.1.1.tgz",
-      "integrity": "sha1-skV5w77U1tOWru5tmorn9Ugqt7s="
+      "integrity": "sha512-9q/rDEGSb/Qsvv2qvzIzdluL5k7AaJOTrw23z9reQthrbF7is4CtlT0DXyO1oei2DCp4uojjzQ7igaSHp1kAEQ=="
     },
     "bytes": {
       "version": "3.1.0",
@@ -311,17 +311,17 @@
     "camelcase": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
-      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
+      "integrity": "sha512-DLIsRzJVBQu72meAKPkWQOLcujdXT32hwdfnkI1frSiSRMK1MofjKHf+MEx0SB6fjEFXL8fBDv1dKymBlOp4Qw=="
     },
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
     },
     "chainsaw": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chainsaw/-/chainsaw-0.1.0.tgz",
-      "integrity": "sha1-XqtQsor+WAdNDVgpE4iCi15fvJg=",
+      "integrity": "sha512-75kWfWt6MEKNC8xYXIdRpDehRYY/tNSgwKaJq+dbbDcxORuVrrQ+SEHoWsniVn9XPYfP4gmdWIeDk/4YNp1rNQ==",
       "requires": {
         "traverse": ">=0.3.0 <0.4"
       }
@@ -334,12 +334,12 @@
     "chromium-pickle-js": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/chromium-pickle-js/-/chromium-pickle-js-0.1.0.tgz",
-      "integrity": "sha1-HUixB9ghJqLz4hHC6iX4A7pVGyE="
+      "integrity": "sha512-0Xkh0X11DQcRnvr9cO7PKX+MPS6CWgLhAaWznlgMaerE+ZmeV8o9hE6o+wlAxEMAVZpaYSUg4zKx1SDHN7gNNQ=="
     },
     "cliui": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+      "integrity": "sha512-0yayqDxWQbqk3ojkYqUKqaAQ6AfNKeKWRNA8kR0WXzAsdHpP4BIaOmMAG87JGuO6qcobyW4GjxHd9PmhEd+T9w==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1",
@@ -349,7 +349,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha512-RpAVKQA5T63xEj6/giIbUEtZwJ4UFIc3ZtvEkiaUERylqe8xb5IvqcgOurZLahv93CLKfxcw5YI+DZcUBRyLXA=="
     },
     "coffee-script": {
       "version": "1.12.7",
@@ -374,7 +374,7 @@
         "coffee-script": {
           "version": "1.11.1",
           "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.11.1.tgz",
-          "integrity": "sha1-vxxHrWREOg2V0S3ysUfMCk2q1uk=",
+          "integrity": "sha512-NIWm59Fh1zkXq6TS6PQvSO3AR9DbGq1IBNZHa1E3fUCNmJhIwLf1YKcWgaHqaU7zWGC/OE2V7K3GVAXFzcmu+A==",
           "dev": true
         },
         "resolve": {
@@ -386,7 +386,7 @@
         "strip-json-comments": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-1.0.4.tgz",
-          "integrity": "sha1-HhX7ysl9Pumb8tc7TGVrCCu6+5E=",
+          "integrity": "sha512-AOPG8EBc5wAikaG1/7uFCNFJwnKOuQwFTpYBdTW6OvWHeZBQBrAA/amefHGrEiOnCPcLFZK6FUPtWVKpQVIRgg==",
           "dev": true
         }
       }
@@ -493,12 +493,12 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
     },
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+      "integrity": "sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ=="
     },
     "content-disposition": {
       "version": "0.5.3",
@@ -524,7 +524,7 @@
     "cookie-signature": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw=",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "dev": true
     },
     "core-util-is": {
@@ -535,7 +535,7 @@
     "cson-parser": {
       "version": "1.3.5",
       "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
-      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "integrity": "sha512-Pchz4dDkyafUL4V3xBuP9Os8Hu9VU96R+MxuTKh7NR+D866UiWrhBiSLbfuvwApEaJzpXhXTr3iPe4lFtXLzcQ==",
       "requires": {
         "coffee-script": "^1.10.0"
       },
@@ -550,12 +550,12 @@
     "cuint": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
-      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+      "integrity": "sha512-d4ZVpCW31eWwCMe1YT3ur7mUDnTXbgwyzaL320DrcRT45rfjYxkt5QWLrmOJ+/UEAI2+fQgKe/fCjR8l4TpRgw=="
     },
     "d": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/d/-/d-0.1.1.tgz",
-      "integrity": "sha1-2hhMU10Y2O57oqoim5FACfrhEwk=",
+      "integrity": "sha512-0SdM9V9pd/OXJHoWmTfNPTAeD+lw6ZqHg+isPyBFuJsZLSE0Ygg1cYZ/0l6DrKQXMOqGOu1oWupMoOfoRfMZrQ==",
       "requires": {
         "es5-ext": "~0.10.2"
       }
@@ -563,7 +563,7 @@
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -580,7 +580,7 @@
     "decamelize": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA=="
     },
     "decompress-response": {
       "version": "4.2.1",
@@ -619,12 +619,12 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -646,7 +646,7 @@
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
       "requires": {
         "jsbn": "~0.1.0",
         "safer-buffer": "^2.1.0"
@@ -655,13 +655,13 @@
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0=",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
       "dev": true
     },
     "emissary": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/emissary/-/emissary-1.3.3.tgz",
-      "integrity": "sha1-phjZLWgrIy0xER3DYlpd9mF5lgY=",
+      "integrity": "sha512-pD6FWNBSlEOzSJDCTcSGVLgNnGw5fnCvvGMdQ/TN43efeXZ/QTq8+hZoK3OOEXPRNjMmSJmeOnEJh+bWT5O8rQ==",
       "requires": {
         "es6-weak-map": "^0.1.2",
         "mixto": "1.x",
@@ -672,7 +672,7 @@
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
       "dev": true
     },
     "end-of-stream": {
@@ -732,7 +732,7 @@
     "es6-iterator": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-0.1.3.tgz",
-      "integrity": "sha1-1vWLjE/EE8JJtLqhl2j45NfIlE4=",
+      "integrity": "sha512-6TOmbFM6OPWkTe+bQ3ZuUkvqcWUjAnYjKUCLdbvRsAUz2Pr+fYIibwNXNkLNtIK9PPFbNMZZddaRNkyJhlGJhA==",
       "requires": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.5",
@@ -742,7 +742,7 @@
     "es6-symbol": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-2.0.1.tgz",
-      "integrity": "sha1-dhtcZ8/U8dGK+yNPaR1nhoLLO/M=",
+      "integrity": "sha512-wjobO4zO8726HVU7mI2OA/B6QszqwHJuKab7gKHVx+uRfVVYGcWJkCIFxV2Madqb9/RUSrhJ/r6hPfG7FsWtow==",
       "requires": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.5"
@@ -751,7 +751,7 @@
     "es6-weak-map": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-0.1.4.tgz",
-      "integrity": "sha1-cGzvnpmqI2undmwjnIueKG6n0ig=",
+      "integrity": "sha512-P+N5Cd2TXeb7G59euFiM7snORspgbInS29Nbf3KNO2JQp/DyhvMCDWd58nsVAXwYJ6W3Bx7qDdy6QQ3PCJ7jKQ==",
       "requires": {
         "d": "~0.1.1",
         "es5-ext": "~0.10.6",
@@ -762,13 +762,13 @@
     "escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
       "dev": true
     },
     "etag": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc=",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
       "dev": true
     },
     "event-kit": {
@@ -850,7 +850,7 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g=="
     },
     "fast-deep-equal": {
       "version": "3.1.3",
@@ -865,7 +865,7 @@
     "fileset": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/fileset/-/fileset-0.1.8.tgz",
-      "integrity": "sha1-UGuRqTluqn4y+0KoQHfHoMc2t0E=",
+      "integrity": "sha512-Gg0/Iy/v4BfdGWZpbpVBPKIYcap7jMn2uT5lcIDZyMFZR35VDojrJnIAwWjCj7ZOqsGp3j+ExWKqnfGrz4q0fg==",
       "dev": true,
       "requires": {
         "glob": "3.x",
@@ -875,7 +875,7 @@
         "glob": {
           "version": "3.2.11",
           "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.11.tgz",
-          "integrity": "sha1-Spc/Y1uRkPcV0QmH1cAP0oFevj0=",
+          "integrity": "sha512-hVb0zwEZwC1FXSKRPFTeOtN7AArJcJlI6ULGLtrstaswKNlrTJqAA+1lYlSUop4vjA423xlBzqfVS3iWGlqJ+g==",
           "dev": true,
           "requires": {
             "inherits": "2",
@@ -885,7 +885,7 @@
             "minimatch": {
               "version": "0.3.0",
               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.3.0.tgz",
-              "integrity": "sha1-J12O2qxPG7MyZHIInnlJyDlGmd0=",
+              "integrity": "sha512-WFX1jI1AaxNTZVOHLBVazwTWKaQjoykSzCBNXB72vDTCzopQGtyP91tKdFK5cv1+qMwPyiTu1HqUriqplI8pcA==",
               "dev": true,
               "requires": {
                 "lru-cache": "2",
@@ -897,7 +897,7 @@
         "minimatch": {
           "version": "0.4.0",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.4.0.tgz",
-          "integrity": "sha1-vSx9Bg0sjI/Xzefx8u0tWycP2xs=",
+          "integrity": "sha512-yJKJL1g3to7f4C/9LzHXTzNh550xKGefiCls9RS+DDdsDpKpndY49UDZW5sj/3yeac3Hl2Px3w5bT8bM/dMrWQ==",
           "dev": true,
           "requires": {
             "lru-cache": "2",
@@ -938,7 +938,7 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw=="
     },
     "form-data": {
       "version": "2.3.3",
@@ -959,7 +959,7 @@
     "fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac=",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "dev": true
     },
     "fs-constants": {
@@ -970,7 +970,7 @@
     "fs-extra": {
       "version": "0.26.7",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-0.26.7.tgz",
-      "integrity": "sha1-muH92UiXeY7at20JGM9C0MMYT6k=",
+      "integrity": "sha512-waKu+1KumRhYv8D8gMRCKJGAMI9pRnPuEb1mvgYD0f7wBscg+h6bW4FDTmEZhB9VKxvoTtxW+Y7bnIlB7zja6Q==",
       "requires": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^2.1.0",
@@ -1012,7 +1012,7 @@
         "async": {
           "version": "1.5.2",
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+          "integrity": "sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w=="
         },
         "rimraf": {
           "version": "2.7.1",
@@ -1027,7 +1027,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
+      "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -1038,7 +1038,7 @@
     "gauge": {
       "version": "2.7.4",
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "integrity": "sha512-14x4kjc6lkD3ltw589k0NrPD6cCNTD6CWoVUNpB85+DrtONoZn+Rug6xZU5RvSC4+TZPxA5AnBibQYAvZn41Hg==",
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -1053,7 +1053,7 @@
     "gaze": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/gaze/-/gaze-0.3.4.tgz",
-      "integrity": "sha1-X5S92gr+U7xxCWm81vKCVI1gwnk=",
+      "integrity": "sha512-vIK81ZT20o9X0LOHYDGo5Phq6FaQRjDjBN2KkbYSxlaXnN1WDH0Op0tPThqNVA8ZnmN/TYNZfGHAVkBTrdeBIQ==",
       "dev": true,
       "requires": {
         "fileset": "~0.1.5",
@@ -1063,7 +1063,7 @@
         "minimatch": {
           "version": "0.2.14",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz",
-          "integrity": "sha1-x054BXT2PG+aCQ6Q775u9TpqdWo=",
+          "integrity": "sha512-zZ+Jy8lVWlvqqeM8iZB7w7KmQkoJn8djM585z88rywrEbzoqawVa9FR5p2hwD+y74nfuKOjmNvi9gtWJNLqHvA==",
           "dev": true,
           "requires": {
             "lru-cache": "2",
@@ -1075,7 +1075,7 @@
     "getpass": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
       "requires": {
         "assert-plus": "^1.0.0"
       }
@@ -1099,7 +1099,7 @@
     "github-from-package": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "glob": {
       "version": "7.1.6",
@@ -1130,7 +1130,7 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q=="
     },
     "har-validator": {
       "version": "5.1.5",
@@ -1153,7 +1153,7 @@
     "has-unicode": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ=="
     },
     "hosted-git-info": {
       "version": "3.0.7",
@@ -1189,7 +1189,7 @@
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
       "requires": {
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
@@ -1219,7 +1219,7 @@
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -1244,7 +1244,7 @@
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-      "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
+      "integrity": "sha512-xgs2NH9AE66ucSq4cNG1nhSFghr5l6tdL15Pk+jl46bmmBapgoaY/AacXyaDznAqmGL99TiLSQgO/XazFSKYeQ=="
     },
     "ipaddr.js": {
       "version": "1.9.1",
@@ -1269,7 +1269,7 @@
     "is-fullwidth-code-point": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "integrity": "sha512-1pqUqRjkhPJ9miNq9SwMfdvi6lBJcd6eFxvfaivQhaH3SgisfiuudvFntdKOmxuee/77l+FPjKrQjWvmPjWrRw==",
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -1277,7 +1277,7 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
     },
     "is-wsl": {
       "version": "2.2.0",
@@ -1290,23 +1290,23 @@
     "isarray": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
     },
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
     },
     "jasmine-focused": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/jasmine-focused/-/jasmine-focused-1.0.7.tgz",
-      "integrity": "sha1-uDx1fIAOaOHW78GjoaE/85/23NI=",
+      "integrity": "sha512-FYJImuqPz3O0T1aOBrRfwgGNMfp/NAa2ywmqDkKWZ1hAxXZ4ZAzfFZ8AK+yKfWpCQSjXFqPuFaKoNTJyvS2sWw==",
       "dev": true,
       "requires": {
         "jasmine-node": "git+https://github.com/kevinsawicki/jasmine-node.git#81af4f953a2b7dfb5bde8331c05362a4b464c5ef",
@@ -1350,7 +1350,7 @@
     "jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+      "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
     },
     "json-schema": {
       "version": "0.2.3",
@@ -1365,12 +1365,12 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
     },
     "jsonfile": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
-      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "integrity": "sha512-PKllAqbgLgxHaj8TElYymKCAgrASebJrWpTnEkOaTowt23VKXXN0sUeriJ+eh7y6ufb/CC5ap11pz71/cM0hUw==",
       "requires": {
         "graceful-fs": "^4.1.6"
       }
@@ -1398,7 +1398,7 @@
     "klaw": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
-      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "integrity": "sha512-TED5xi9gGQjGpNnvRWknrwAB1eL5GciPfVFOt3Vk1OJCVDQbzuSfrF3hkUQKlsgKrG1F+0t5W0m+Fje1jIt8rw==",
       "requires": {
         "graceful-fs": "^4.1.9"
       }
@@ -1406,7 +1406,7 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "integrity": "sha512-YiGkH6EnGrDGqLMITnGjXtGmNtjoXw9SVUzcaos8RBi7Ps0VBylkq+vOcY9QE5poLasPCR849ucFUkl0UzUyOw==",
       "requires": {
         "invert-kv": "^1.0.0"
       }
@@ -1420,19 +1420,19 @@
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g=",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
       "dev": true
     },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E=",
+      "integrity": "sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==",
       "dev": true
     },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
       "dev": true
     },
     "mime": {
@@ -1502,7 +1502,7 @@
     "mixto": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/mixto/-/mixto-1.0.0.tgz",
-      "integrity": "sha1-wyDvYbUvKJj1IuF9i7xtUG2EJbY="
+      "integrity": "sha512-g2Kg8O3ww9RbWuPnAgTsAhe+aBwVXoo/lhYyDKTYPiLKdJofAr97O8zTFzW5UfiJUoeJbmXLmcjDAF7/Egwi8Q=="
     },
     "mkdirp": {
       "version": "0.5.1",
@@ -1520,7 +1520,7 @@
     "mkpath": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
-      "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE="
+      "integrity": "sha512-bauHShmaxVQiEvlrAPWxSPn8spSL8gDVRl11r8vLT4r/KdnknLqtqwQbToZ2Oa8sJkExYY1z6/d+X7pNiqo4yg=="
     },
     "mksnapshot": {
       "version": "0.3.5",
@@ -1535,7 +1535,7 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
       "dev": true
     },
     "mute-stream": {
@@ -1546,7 +1546,7 @@
     "mv": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
-      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
+      "integrity": "sha512-at/ZndSy3xEGJ8i0ygALh8ru9qy7gWW1cmkaqBN29JmMlIvM//MEO9y1sk/avxuwnPcfhkejkLsuPxH81BrkSg==",
       "requires": {
         "mkdirp": "~0.5.1",
         "ncp": "~2.0.0",
@@ -1556,7 +1556,7 @@
         "glob": {
           "version": "6.0.4",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "integrity": "sha512-MKZeRNyYZAVVVG1oZeLaWie1uweH40m9AZwIwxyPbTSX4hHrVYSzLg0Ro5Z5R7XKkIX+Cc6oD1rqeDJnwsB8/A==",
           "requires": {
             "inflight": "^1.0.4",
             "inherits": "2",
@@ -1568,7 +1568,7 @@
         "rimraf": {
           "version": "2.4.5",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "integrity": "sha512-J5xnxTyqaiw06JjMftq7L9ouA448dw/E7dKghkP9WpKNuwmARNNg+Gk8/u5ryb9N/Yo2+z3MCwuqFK/+qPOPfQ==",
           "requires": {
             "glob": "^6.0.1"
           }
@@ -1588,7 +1588,7 @@
     "ncp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
-      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M="
+      "integrity": "sha512-zIdGUrPRFTUELUvr3Gmc7KZ2Sw/h1PiVM0Af/oHB6zgnV1ikqSfRk+TOufi79aHYCW3NiOXmr1BP5nWbzojLaA=="
     },
     "negotiator": {
       "version": "0.6.2",
@@ -1702,7 +1702,7 @@
     "nopt": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz",
-      "integrity": "sha1-xkZdvwirzU2zWTF/eaxopkayj/k=",
+      "integrity": "sha512-4GUt3kSEYmk4ITxzB/b9vaIDfUVWN/Ml1Fwl11IlnIG2iaJ9O6WXZ9SrYM9NLI8OCBieN2Y8SWC2oJV0RQ7qYg==",
       "requires": {
         "abbrev": "1"
       }
@@ -1839,7 +1839,8 @@
       "dependencies": {
         "JSONStream": {
           "version": "1.3.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
           "requires": {
             "jsonparse": "^1.2.0",
             "through": ">=2.2.7 <3"
@@ -1847,59 +1848,70 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "agent-base": {
           "version": "4.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
           "requires": {
             "es6-promisify": "^5.0.0"
           }
         },
         "agentkeepalive": {
           "version": "3.5.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-e0L/HNe6qkQ7H19kTlRRqUibEAwDK5AFk6y3PtMsuut2VAH6+Q4xZml1tNDJD7kSAyqmbG/K08K5WEJYtUrSlQ==",
           "requires": {
             "humanize-ms": "^1.2.1"
           }
         },
         "ansi-align": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
           "requires": {
             "string-width": "^2.0.0"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "ansi-styles": {
           "version": "3.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
           "requires": {
             "color-convert": "^1.9.0"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ZlWX3oap/+Oqm/vmyuXG6kJrSXk="
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk="
         },
         "aproba": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-lYe4Gx7QT+MKGbDsA+Z+he/Wtef0BiwDOlK/XkBrdfsh9J/jPPXbX0tE9x9cl27Tmu5gg3QUbUrQYa/y+KOHPQ=="
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-+cjBN1fMHde8N5rHeyxipcKGjEA="
         },
         "are-we-there-yet": {
           "version": "1.1.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
           "requires": {
             "delegates": "^1.0.0",
             "readable-stream": "^2.0.6"
@@ -1907,7 +1919,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -1920,7 +1933,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -1929,38 +1943,46 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY="
         },
         "asn1": {
           "version": "0.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
           "requires": {
             "safer-buffer": "~2.1.0"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
           "optional": true,
           "requires": {
             "tweetnacl": "^0.14.3"
@@ -1968,7 +1990,8 @@
         },
         "bin-links": {
           "version": "1.1.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KgmVfx+QqggqP9dA3iIc5pA4T1qEEEL+hOhOhNPaUm77OTrJoOXE/C05SJLNJe6m/2wUK7F1tDSou7n5TfCDzQ==",
           "requires": {
             "bluebird": "^3.5.3",
             "cmd-shim": "^3.0.0",
@@ -1980,11 +2003,13 @@
         },
         "bluebird": {
           "version": "3.5.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w=="
         },
         "boxen": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
           "requires": {
             "ansi-align": "^2.0.0",
             "camelcase": "^4.0.0",
@@ -1997,7 +2022,8 @@
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2005,23 +2031,28 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA=="
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
         },
         "byte-size": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-/XuKeqWocKsYa/cBY1YbSJSWWqTi4cFgr9S6OyM7PBaPbr9zvNGwWP33vt0uqGhwDdN+y3yhbXVILEUpnwEWGw=="
         },
         "cacache": {
           "version": "12.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
           "requires": {
             "bluebird": "^3.5.5",
             "chownr": "^1.1.1",
@@ -2042,23 +2073,28 @@
         },
         "call-limit": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-5twvci5b9eRBw2wCfPtN0GmlR2/gadZqyFpPhOK6CvMFoFgA+USnZ6Jpu1lhG9h85pQ3Ouil3PfXWRD4EUaRiQ=="
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "chalk": {
           "version": "2.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
           "requires": {
             "ansi-styles": "^3.2.1",
             "escape-string-regexp": "^1.0.5",
@@ -2067,26 +2103,31 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
         },
         "ci-info": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "cidr-regex": {
           "version": "2.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-sB3ogMQXWvreNPbJUZMRApxuRYd+KoIo4RGQ81VatjmMW6WJPo+IJZ2846FGItr9VzKo5w7DXzijPLGtSd0N3Q==",
           "requires": {
             "ip-regex": "^2.1.0"
           }
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
         },
         "cli-columns": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZzLZcpee/CrkRKHwjgj6E5yWoY4=",
           "requires": {
             "string-width": "^2.0.0",
             "strip-ansi": "^3.0.1"
@@ -2094,7 +2135,8 @@
         },
         "cli-table3": {
           "version": "0.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-7Qg2Jrep1S/+Q3EceiZtQcDPWxhAvBw+ERf1162v4sikJrvojMHFqXt8QIVha8UlH9rgU0BeWPytZ9/TzYqlUw==",
           "requires": {
             "colors": "^1.1.2",
             "object-assign": "^4.1.0",
@@ -2103,7 +2145,8 @@
         },
         "cliui": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
           "requires": {
             "string-width": "^3.1.0",
             "strip-ansi": "^5.2.0",
@@ -2112,15 +2155,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -2129,7 +2175,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -2138,11 +2185,13 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
         },
         "cmd-shim": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DtGg+0xiFhQIntSBRzL2fRQBnmtAVwXIDo4Qq46HPpObYquxMaZS4sb82U9nH91qJrlosC1wa9gwr0QyL/HypA==",
           "requires": {
             "graceful-fs": "^4.1.2",
             "mkdirp": "~0.5.0"
@@ -2150,27 +2199,32 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "color-convert": {
           "version": "1.9.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
           "requires": {
             "color-name": "^1.1.1"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
         },
         "colors": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg==",
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Rzfd8ce2mop8NAVweC6UfuyOeLs=",
           "requires": {
             "strip-ansi": "^3.0.0",
             "wcwidth": "^1.0.0"
@@ -2178,18 +2232,21 @@
         },
         "combined-stream": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
           "requires": {
             "delayed-stream": "~1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "concat-stream": {
           "version": "1.6.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
           "requires": {
             "buffer-from": "^1.0.0",
             "inherits": "^2.0.3",
@@ -2199,7 +2256,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2212,7 +2270,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -2221,7 +2280,8 @@
         },
         "config-chain": {
           "version": "1.1.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-a1eOIcu8+7lUInge4Rpf/n4Krkf3Dd9lqhljRzII1/Zno/kRtUWnznPO3jOKBmTEktkt3fkxisUcivoj0ebzoA==",
           "requires": {
             "ini": "^1.3.4",
             "proto-list": "~1.2.1"
@@ -2229,7 +2289,8 @@
         },
         "configstore": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nlOhI4+fdzoK5xmJ+NY+1gZK56bwEaWZr8fYuXohZ9Vkc1o3a4T/R3M+yE/w7x/ZVJ1zF8c+oaOvF0dztdUgmA==",
           "requires": {
             "dot-prop": "^4.2.1",
             "graceful-fs": "^4.1.2",
@@ -2241,11 +2302,13 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "copy-concurrently": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-f2domd9fsVDFtaFcbaRZuYXwtdmnzqbADSwhSWYxYB/Q8zsdUUFMXVRwXGDMWmbEzAn1kdRrtI1T/KTFOL4X2A==",
           "requires": {
             "aproba": "^1.1.1",
             "fs-write-stream-atomic": "^1.0.8",
@@ -2257,28 +2320,33 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "create-error-class": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
           "requires": {
             "capture-stack-trace": "^1.0.0"
           }
         },
         "cross-spawn": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
           "requires": {
             "lru-cache": "^4.0.1",
             "shebang-command": "^1.2.0",
@@ -2287,7 +2355,8 @@
           "dependencies": {
             "lru-cache": {
               "version": "4.1.5",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==",
               "requires": {
                 "pseudomap": "^1.0.2",
                 "yallist": "^2.1.2"
@@ -2295,87 +2364,104 @@
             },
             "yallist": {
               "version": "2.1.2",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
             }
           }
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-GzN5LhHpFKL9bW7WRHRkRE5fpkA="
         },
         "dashdash": {
           "version": "1.14.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "debug": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI="
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU="
         },
         "deep-extend": {
           "version": "0.6.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "defaults": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xlYFHpgX2f8I7YgUd/P+QBnz730=",
           "requires": {
             "clone": "^1.0.2"
           }
         },
         "define-properties": {
           "version": "1.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
           "requires": {
             "object-keys": "^1.0.12"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-9B8cEL5LAOh7XxPaaAdZ8sW/0+I="
         },
         "dezalgo": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=",
           "requires": {
             "asap": "^2.0.0",
             "wrappy": "1"
@@ -2383,22 +2469,26 @@
         },
         "dot-prop": {
           "version": "4.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==",
           "requires": {
             "is-obj": "^1.0.0"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow=="
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
         },
         "duplexify": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
           "requires": {
             "end-of-stream": "^1.0.0",
             "inherits": "^2.0.1",
@@ -2408,7 +2498,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2421,7 +2512,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -2430,7 +2522,8 @@
         },
         "ecc-jsbn": {
           "version": "0.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
           "optional": true,
           "requires": {
             "jsbn": "~0.1.0",
@@ -2439,44 +2532,52 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-YMf4e9YrzGqJT6jM1q+3gjok90I="
         },
         "emoji-regex": {
           "version": "7.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA=="
         },
         "encoding": {
           "version": "0.1.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
           "requires": {
             "iconv-lite": "~0.4.13"
           }
         },
         "end-of-stream": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
           "requires": {
             "once": "^1.4.0"
           }
         },
         "env-paths": {
           "version": "2.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA=="
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA="
         },
         "errno": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
           "requires": {
             "prr": "~1.0.1"
           }
         },
         "es-abstract": {
           "version": "1.12.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
           "requires": {
             "es-to-primitive": "^1.1.1",
             "function-bind": "^1.1.1",
@@ -2487,7 +2588,8 @@
         },
         "es-to-primitive": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qZryBOJjV//LaxLTV6UC//WewneB3LcXOL9NP++ozKVXsIIIpm/2c13UDiD9Jp2eThsecw9m3jPqDwTyobcdbg==",
           "requires": {
             "is-callable": "^1.1.4",
             "is-date-object": "^1.0.1",
@@ -2496,22 +2598,26 @@
         },
         "es6-promise": {
           "version": "4.2.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w=="
         },
         "es6-promisify": {
           "version": "5.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
           "requires": {
             "es6-promise": "^4.0.3"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
         },
         "execa": {
           "version": "0.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
           "requires": {
             "cross-spawn": "^5.0.1",
             "get-stream": "^3.0.0",
@@ -2524,33 +2630,40 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
             }
           }
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "figgy-pudding": {
           "version": "3.5.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-vNKxJHTEKNThjfrdJwHc7brvM6eVevuO5nTj6ez8ZQ1qbXTvGthucRF7S4vf2cr71QVnT70V34v0S1DyQsti0w=="
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-KEftzJ+H90x6pcKtdXZEPsQse8/y/UnvzRKrOSQFprnrGaFuJ62fVkP34Iu2IYuMvyauCyoLTNkJZgrrGA2wkA=="
         },
         "flush-write-stream": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-calZMC10u0FMUqoiunI2AiGIIUtUIvifNwkHhNupZH4cbNnW1Itkoh/Nf5HFYmDrwWPjrUxpkZT0KhuCq0jmGw==",
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.4"
@@ -2558,7 +2671,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2571,7 +2685,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -2580,11 +2695,13 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
           "requires": {
             "asynckit": "^0.4.0",
             "combined-stream": "1.0.6",
@@ -2593,7 +2710,8 @@
         },
         "from2": {
           "version": "2.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
           "requires": {
             "inherits": "^2.0.1",
             "readable-stream": "^2.0.0"
@@ -2601,7 +2719,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2614,7 +2733,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -2623,14 +2743,16 @@
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
           "requires": {
             "minipass": "^2.6.0"
           },
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -2640,7 +2762,8 @@
         },
         "fs-vacuum": {
           "version": "1.2.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-t2Kb7AekAxolSP35n17PHMizHjY=",
           "requires": {
             "graceful-fs": "^4.1.2",
             "path-is-inside": "^1.0.1",
@@ -2649,7 +2772,8 @@
         },
         "fs-write-stream-atomic": {
           "version": "1.0.10",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-tH31NJPvkR33VzHnCp3tAYnbQMk=",
           "requires": {
             "graceful-fs": "^4.1.2",
             "iferr": "^0.1.5",
@@ -2659,11 +2783,13 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             },
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -2676,7 +2802,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -2685,15 +2812,18 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "function-bind": {
           "version": "1.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "gauge": {
           "version": "2.7.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
             "console-control-strings": "^1.0.0",
@@ -2707,11 +2837,13 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             },
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -2722,11 +2854,13 @@
         },
         "genfun": {
           "version": "5.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-KGDOARWVga7+rnB3z9Sd2Letx515owfk0hSxHGuqjANb1M+x2bGZGqHLiozPsYMdM2OubeMni/Hpwmjq6qIUhA=="
         },
         "gentle-fs": {
           "version": "2.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OlwBBwqCFPcjm33rF2BjW+Pr6/ll2741l+xooiwTCeaX2CA1ZuclavyMBe0/KlR21/XGsgY6hzEQZ15BdNa13Q==",
           "requires": {
             "aproba": "^1.1.2",
             "chownr": "^1.1.2",
@@ -2743,35 +2877,41 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             },
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-xg7taebY/bazEEofy8ocGS3FtQE="
             }
           }
         },
         "get-caller-file": {
           "version": "2.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="
         },
         "get-stream": {
           "version": "4.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
           "requires": {
             "pump": "^3.0.0"
           }
         },
         "getpass": {
           "version": "0.1.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
           "requires": {
             "assert-plus": "^1.0.0"
           }
         },
         "glob": {
           "version": "7.1.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -2783,14 +2923,16 @@
         },
         "global-dirs": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
           "requires": {
             "ini": "^1.3.4"
           }
         },
         "got": {
           "version": "6.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
           "requires": {
             "create-error-class": "^3.0.0",
             "duplexer3": "^0.1.4",
@@ -2807,21 +2949,25 @@
           "dependencies": {
             "get-stream": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
             }
           }
         },
         "graceful-fs": {
           "version": "4.2.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
           "version": "5.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
           "requires": {
             "ajv": "^6.12.3",
             "har-schema": "^2.0.0"
@@ -2829,7 +2975,8 @@
           "dependencies": {
             "ajv": {
               "version": "6.12.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
               "requires": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -2839,44 +2986,53 @@
             },
             "fast-deep-equal": {
               "version": "3.1.3",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
             },
             "json-schema-traverse": {
               "version": "0.4.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
             }
           }
         },
         "has": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
           "requires": {
             "function-bind": "^1.1.1"
           }
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
         },
         "has-symbols": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "hosted-git-info": {
           "version": "2.8.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg=="
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-5ai2iksyV8ZXmnZhHH4rWPoxxistEexSi5936zIQ1bnNTW5VnA85B6P/VpXiRM017IgRvb2kKo1a//y+0wSp3w=="
         },
         "http-proxy-agent": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==",
           "requires": {
             "agent-base": "4",
             "debug": "3.1.0"
@@ -2884,7 +3040,8 @@
         },
         "http-signature": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
           "requires": {
             "assert-plus": "^1.0.0",
             "jsprim": "^1.2.2",
@@ -2893,7 +3050,8 @@
         },
         "https-proxy-agent": {
           "version": "2.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==",
           "requires": {
             "agent-base": "^4.3.0",
             "debug": "^3.1.0"
@@ -2901,44 +3059,52 @@
         },
         "humanize-ms": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=",
           "requires": {
             "ms": "^2.0.0"
           }
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
           }
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-9AfeLfji44r5TKInjhz3W9DyZI1zR1JAf2hVBMGhddAKPqBsupb89jGfbCTHIGZd6fGZl9WlHdn4AObygyMKwg=="
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
           "requires": {
             "minimatch": "^3.0.4"
           }
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
         },
         "infer-owner": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A=="
         },
         "inflight": {
           "version": "1.0.6",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
             "wrappy": "1"
@@ -2946,15 +3112,18 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "init-package-json": {
           "version": "1.10.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zKSiXKhQveNteyhcj1CoOP8tqp1QuxPIPBl8Bid99DGLFqA1p87M6lNgfjJHSBoWJJlidGOv5rWjyYKEB3g2Jw==",
           "requires": {
             "glob": "^7.1.1",
             "npm-package-arg": "^4.0.0 || ^5.0.0 || ^6.0.0",
@@ -2968,50 +3137,59 @@
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
         },
         "is-callable": {
           "version": "1.1.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-r5p9sxJjYnArLjObpjA4xu5EKI3CuKHkJXMhT7kwbpUyIFD1n5PMAsoPvWnvtZiNz7LjkYDRZhd7FlI0eMijEA=="
         },
         "is-ci": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-s6tfsaQaQi3JNciBH6shVqEDvhGut0SUXr31ag8Pd8BBbVVlcGfWhpPmEOoM6RJ5TFhbypvf5yyRw/VXW1IiWg==",
           "requires": {
             "ci-info": "^1.5.0"
           },
           "dependencies": {
             "ci-info": {
               "version": "1.6.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-vsGdkwSCDpWmP80ncATX7iea5DWQemg1UgCW5J8tqjU3lYw4FBYuj89J0CTVomA7BEfvSZd84GmHko+MxFQU2A=="
             }
           }
         },
         "is-cidr": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8Xnnbjsb0x462VoYiGlhEi+drY8SFwrHiSYuzc/CEwco55vkehTaxAyIjEdpi3EMvLPPJAJi9FlzP+h+03gp0Q==",
           "requires": {
             "cidr-regex": "^2.0.10"
           }
         },
         "is-date-object": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
           }
         },
         "is-installed-globally": {
           "version": "0.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
           "requires": {
             "global-dirs": "^0.1.0",
             "is-path-inside": "^1.0.0"
@@ -3019,85 +3197,103 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
         },
         "is-path-inside": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
           "requires": {
             "path-is-inside": "^1.0.1"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
         },
         "is-regex": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
           "requires": {
             "has": "^1.0.1"
           }
         },
         "is-retry-allowed": {
           "version": "1.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
         },
         "is-symbol": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
           "requires": {
             "has-symbols": "^1.0.0"
           }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jsbn": {
           "version": "0.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA="
         },
         "jsprim": {
           "version": "1.4.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -3107,18 +3303,21 @@
         },
         "latest-version": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
           "requires": {
             "package-json": "^4.0.0"
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hN3Es3Bnm6i9TNz6TAa0PVcREUc="
         },
         "libcipm": {
           "version": "4.0.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-IN3hh2yDJQtZZ5paSV4fbvJg4aHxCCg5tcZID/dSVlTuUiWktsgaldVljJv6Z5OUlYspx6xQkbR0efNodnIrOA==",
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.1",
@@ -3139,7 +3338,8 @@
         },
         "libnpm": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-d7jU5ZcMiTfBqTUJVZ3xid44fE5ERBm9vBnmhp2ECD2Ls+FNXWxHSkO7gtvrnbLO78gwPdNPz1HpsF3W4rjkBQ==",
           "requires": {
             "bin-links": "^1.1.2",
             "bluebird": "^3.5.3",
@@ -3165,7 +3365,8 @@
         },
         "libnpmaccess": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-01512AK7MqByrI2mfC7h5j8N9V4I7MHJuk9buo8Gv+5QgThpOgpjB7sQBDDkeZqRteFb1QM/6YNdHfG7cDvfAQ==",
           "requires": {
             "aproba": "^2.0.0",
             "get-stream": "^4.0.0",
@@ -3175,7 +3376,8 @@
         },
         "libnpmconfig": {
           "version": "1.2.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-9esX8rTQAHqarx6qeZqmGQKBNZR5OIbl/Ayr0qQDy3oXja2iFVQQI81R6GZ2a02bSNZ9p3YOGX1O6HHCb1X7kA==",
           "requires": {
             "figgy-pudding": "^3.5.1",
             "find-up": "^3.0.0",
@@ -3184,14 +3386,16 @@
           "dependencies": {
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "requires": {
                 "locate-path": "^3.0.0"
               }
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -3199,27 +3403,31 @@
             },
             "p-limit": {
               "version": "2.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
               "requires": {
                 "p-try": "^2.0.0"
               }
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
             }
           }
         },
         "libnpmhook": {
           "version": "5.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-UdNLMuefVZra/wbnBXECZPefHMGsVDTq5zaM/LgKNE9Keyl5YXQTnGAzEo+nFOpdRqTWI9LYi4ApqF9uVCCtuA==",
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -3229,7 +3437,8 @@
         },
         "libnpmorg": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0sRUXLh+PLBgZmARvthhYXQAWn0fOsa6T5l3JSe2n9vKG/lCVK4nuG7pDsa7uMq+uTt2epdPK+a2g6btcY11Ww==",
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -3239,7 +3448,8 @@
         },
         "libnpmpublish": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2yIwaXrhTTcF7bkJKIKmaCV9wZOALf/gsTDxVSu/Gu/6wiG3fA8ce8YKstiWKTxSFNC0R7isPUb6tXTVFZHt2g==",
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.5.1",
@@ -3254,7 +3464,8 @@
         },
         "libnpmsearch": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-VTBbV55Q6fRzTdzziYCr64+f8AopQ1YZ+BdPOv16UegIEaE8C0Kch01wo4s3kRTFV64P121WZJwgmBwrq68zYg==",
           "requires": {
             "figgy-pudding": "^3.5.1",
             "get-stream": "^4.0.0",
@@ -3263,7 +3474,8 @@
         },
         "libnpmteam": {
           "version": "1.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-p420vM28Us04NAcg1rzgGW63LMM6rwe+6rtZpfDxCcXxM0zUTLl7nPFEnRF3JfFBF5skF/yuZDUthTsHgde8QA==",
           "requires": {
             "aproba": "^2.0.0",
             "figgy-pudding": "^3.4.1",
@@ -3273,7 +3485,8 @@
         },
         "libnpx": {
           "version": "10.2.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BPc0D1cOjBeS8VIBKUu5F80s6njm0wbVt7CsGMrIcJ+SI7pi7V0uVPGpEMH9H5L8csOcclTxAXFE2VAsJXUhfA==",
           "requires": {
             "dotenv": "^5.0.1",
             "npm-package-arg": "^6.0.0",
@@ -3287,7 +3500,8 @@
         },
         "lock-verify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-vcLpxnGvrqisKvLQ2C2v0/u7LVly17ak2YSgoK4PrdsYBXQIax19vhKiLfvKNFx7FRrpTnitrpzF/uuCMuorIg==",
           "requires": {
             "npm-package-arg": "^6.1.0",
             "semver": "^5.4.1"
@@ -3295,18 +3509,21 @@
         },
         "lockfile": {
           "version": "1.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==",
           "requires": {
             "signal-exit": "^3.0.2"
           }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw="
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-DrtE5FaBSveQXGIS+iybLVG4Qeg=",
           "requires": {
             "lodash._createset": "~4.0.0",
             "lodash._root": "~3.0.0"
@@ -3314,72 +3531,87 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-5THCdkTPi1epnhftlbNcdIeJOS4="
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI="
         },
         "lodash._createcache": {
           "version": "3.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=",
           "requires": {
             "lodash._getnative": "^3.0.0"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY="
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U="
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-+6HEUkwZ7ppfgTa0YJ8BfPTe1pI="
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU="
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-SLtQiECfFvGCFmZkHETdGqrjzYg="
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M="
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PNRXSgC2e643OpS3SHcmQFB7eqw="
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA=="
         },
         "lru-cache": {
           "version": "5.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
           "requires": {
             "yallist": "^3.0.2"
           }
         },
         "make-dir": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
           "requires": {
             "pify": "^3.0.0"
           }
         },
         "make-fetch-happen": {
           "version": "5.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-07JHC0r1ykIoruKO8ifMXu+xEU8qOXDFETylktdug6vJDACnP+HKevOu3PXyNPzFyTSlz8vrBYlBO1JZRe8Cag==",
           "requires": {
             "agentkeepalive": "^3.4.1",
             "cacache": "^12.0.0",
@@ -3396,40 +3628,47 @@
         },
         "meant": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-KN+1uowN/NK+sT/Lzx7WSGIj2u+3xe5n2LbwObfjOhPZiA+cCfCm6idVl0RkEfjThkw5XJ96CyRcanq6GmKtUg=="
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-JWT/IcCTsB0Io3AhWUMjRqucrHSPsSf2xKLaRldJVULioggvkJvggZ3VXNNSRkCddE6D+BUI4HEIZIA2OjwIvg=="
         },
         "mime-types": {
           "version": "2.1.19",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-P1tKYHVSZ6uFo26mtnve4HQFE3koh1UWVkp8YUC+ESBHe945xWSoXuHHiGarDqcEZ+whpCDnlNw5LON0kLo+sw==",
           "requires": {
             "mime-db": "~1.35.0"
           }
         },
         "minimatch": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "1.2.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
         },
         "minizlib": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
           "requires": {
             "minipass": "^2.9.0"
           },
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3439,7 +3678,8 @@
         },
         "mississippi": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-x471SsVjUtBRtcvd4BzKE9kFC+/2TeWgKCgw0bZcw1b9l2X3QX5vCWgF+KaZaYm87Ss//rHnWryupDrgLvmSkA==",
           "requires": {
             "concat-stream": "^1.5.0",
             "duplexify": "^3.4.2",
@@ -3455,20 +3695,23 @@
         },
         "mkdirp": {
           "version": "0.5.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
           "requires": {
             "minimist": "^1.2.5"
           },
           "dependencies": {
             "minimist": {
               "version": "1.2.5",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
             }
           }
         },
         "move-concurrently": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-viwAX9oy4LKa8fBdfEszIUxwH5I=",
           "requires": {
             "aproba": "^1.1.1",
             "copy-concurrently": "^1.0.0",
@@ -3480,21 +3723,25 @@
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             }
           }
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
         },
         "node-fetch-npm": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nJIxm1QmAj4v3nfCvEeCrYSoVwXyxLnaPBK5W1W5DGEJwjlKuC2VEUycGw5oxk+4zZahRrB84PUJJgEmhFTDFw==",
           "requires": {
             "encoding": "^0.1.11",
             "json-parse-better-errors": "^1.0.0",
@@ -3503,7 +3750,8 @@
         },
         "node-gyp": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-OUTryc5bt/P8zVgNUmC6xdXiDJxLMAW8cF5tLQOT9E5sOQj+UeQxnnPy74K3CLCa/SOjjBlbuzDLR8ANwA+wmw==",
           "requires": {
             "env-paths": "^2.2.0",
             "glob": "^7.1.4",
@@ -3520,7 +3768,8 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
           "requires": {
             "abbrev": "1",
             "osenv": "^0.1.4"
@@ -3528,7 +3777,8 @@
         },
         "normalize-package-data": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
           "requires": {
             "hosted-git-info": "^2.1.4",
             "resolve": "^1.10.0",
@@ -3538,7 +3788,8 @@
           "dependencies": {
             "resolve": {
               "version": "1.10.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
               "requires": {
                 "path-parse": "^1.0.6"
               }
@@ -3547,7 +3798,8 @@
         },
         "npm-audit-report": {
           "version": "1.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-8nH/JjsFfAWMvn474HB9mpmMjrnKb1Hx/oTAdjv4PT9iZBvBxiZ+wtDUapHCJwLqYGQVPaAfs+vL5+5k9QndXw==",
           "requires": {
             "cli-table3": "^0.5.0",
             "console-control-strings": "^1.1.0"
@@ -3555,25 +3807,29 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
           "requires": {
             "npm-normalize-package-bin": "^1.0.1"
           }
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-3tMGxbC/yHCp6fr4I7xfKD4FrhE="
         },
         "npm-install-checks": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-E4kzkyZDIWoin6uT5howP8VDvkM+E8IQDcHAycaAxMbwkqhIg5eEYALnXOl3Hq9MrkdQB/2/g1xwBINXdKSRkg==",
           "requires": {
             "semver": "^2.3.0 || 3.x || 4 || 5"
           }
         },
         "npm-lifecycle": {
           "version": "3.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
           "requires": {
             "byline": "^5.0.0",
             "graceful-fs": "^4.1.15",
@@ -3587,15 +3843,18 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-AJI/qxDB2PWI4LG1CYN579AY1vCiNyWfkiquCsJWqntRu/WwimVrC8yXeILBFHDwxfOejxewlmnvW9XXjMlYIg=="
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA=="
         },
         "npm-package-arg": {
           "version": "6.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==",
           "requires": {
             "hosted-git-info": "^2.7.1",
             "osenv": "^0.1.5",
@@ -3605,7 +3864,8 @@
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
           "requires": {
             "ignore-walk": "^3.0.1",
             "npm-bundled": "^1.0.1",
@@ -3614,7 +3874,8 @@
         },
         "npm-pick-manifest": {
           "version": "3.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-wNprTNg+X5nf+tDi+hbjdHhM4bX+mKqv6XmPh7B5eG+QY9VARfQPfCEH013H5GqfNj6ee8Ij2fg8yk0mzps1Vw==",
           "requires": {
             "figgy-pudding": "^3.5.1",
             "npm-package-arg": "^6.0.0",
@@ -3623,7 +3884,8 @@
         },
         "npm-profile": {
           "version": "4.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ta8xq8TLMpqssF0H60BXS1A90iMoM6GeKwsmravJ6wYjWwSzcYBTdyWa3DZCYqPutacBMEm7cxiOkiIeCUAHDQ==",
           "requires": {
             "aproba": "^1.1.2 || 2",
             "figgy-pudding": "^3.4.1",
@@ -3632,7 +3894,8 @@
         },
         "npm-registry-fetch": {
           "version": "4.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-cny9v0+Mq6Tjz+e0erFAB+RYJ/AVGzkjnISiobqP8OWj9c9FLoZZu8/SPSKJWE17F1tk4018wfjV+ZbIbqC7fQ==",
           "requires": {
             "JSONStream": "^1.3.4",
             "bluebird": "^3.5.1",
@@ -3645,24 +3908,28 @@
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
             }
           }
         },
         "npm-run-path": {
           "version": "2.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
           "requires": {
             "path-key": "^2.0.0"
           }
         },
         "npm-user-validate": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-uQwcd/tY+h1jnEaze6cdX/LrhWhoBxfSknxentoqmIuStxUExxjWd3ULMLFPiFUrZKbOVMowH6Jq2FRWfmhcEw=="
         },
         "npmlog": {
           "version": "4.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
             "console-control-strings": "~1.1.0",
@@ -3672,23 +3939,28 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "object-keys": {
           "version": "1.0.12",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
         },
         "object.getownpropertydescriptors": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
           "requires": {
             "define-properties": "^1.1.2",
             "es-abstract": "^1.5.1"
@@ -3696,26 +3968,31 @@
         },
         "once": {
           "version": "1.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
           }
         },
         "opener": {
           "version": "1.5.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-goYSy5c2UXE4Ra1xixabeVh1guIX/ZV/YokJksb6q2lubWu6UbvPQ20p542/sFIll1nl8JnCyK9oBaOcCWXwvA=="
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
             "os-tmpdir": "^1.0.0"
@@ -3723,11 +4000,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
         },
         "package-json": {
           "version": "4.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
           "requires": {
             "got": "^6.7.1",
             "registry-auth-token": "^3.0.1",
@@ -3737,7 +4016,8 @@
         },
         "pacote": {
           "version": "9.5.12",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BUIj/4kKbwWg4RtnBncXPJd15piFSVNpTzY0rysSr3VnMowTYgkGKcaHrbReepAkjTr8lH2CVWRi58Spg2CicQ==",
           "requires": {
             "bluebird": "^3.5.3",
             "cacache": "^12.0.2",
@@ -3773,7 +4053,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3783,7 +4064,8 @@
         },
         "parallel-transform": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-1BDwZbBdojCB/NEPKIVMKb2jOwY=",
           "requires": {
             "cyclist": "~0.2.2",
             "inherits": "^2.0.3",
@@ -3792,7 +4074,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -3805,7 +4088,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -3814,47 +4098,58 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
         },
         "path-parse": {
           "version": "1.0.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-mEcocL8igTL8vdhoEputEsPAKeM="
         },
         "promise-retry": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=",
           "requires": {
             "err-code": "^1.0.0",
             "retry": "^0.10.0"
@@ -3862,43 +4157,51 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-JqXW7ox97kyxIggwWs+5O6OCqe4=",
           "requires": {
             "read": "1"
           }
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-IS1b/hMYMGpCD2QCuOJv85ZHqEk="
         },
         "protoduck": {
           "version": "5.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-WxoCeDCoCBY55BMvj4cAEjdVUFGRWed9ZxPlqTKYyw1nDDTQ4pqmnIMAGfJlg7Dx35uB/M+PHJPTmGOvaCaPTg==",
           "requires": {
             "genfun": "^5.0.0"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
         },
         "pump": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "once": "^1.3.1"
@@ -3906,7 +4209,8 @@
         },
         "pumpify": {
           "version": "1.5.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
           "requires": {
             "duplexify": "^3.6.0",
             "inherits": "^2.0.3",
@@ -3915,7 +4219,8 @@
           "dependencies": {
             "pump": {
               "version": "2.0.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
               "requires": {
                 "end-of-stream": "^1.1.0",
                 "once": "^1.3.1"
@@ -3925,19 +4230,23 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-EXtzRZmC+YGmGlDFbXKxQiMZNwCLEO6BANKXG4iCtSIM0yqc/pappSx3RIKr4r0uh5JsBckOXeKrB3Iz7mdQpQ=="
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
         },
         "query-string": {
           "version": "6.8.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==",
           "requires": {
             "decode-uri-component": "^0.2.0",
             "split-on-first": "^1.0.0",
@@ -3946,11 +4255,13 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-77/cdA+a0FQwRCassYNBLMi5ltQ="
         },
         "rc": {
           "version": "1.2.8",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
             "ini": "~1.3.0",
@@ -3960,21 +4271,24 @@
         },
         "read": {
           "version": "1.0.7",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
           "requires": {
             "mute-stream": "~0.0.4"
           }
         },
         "read-cmd-shim": {
           "version": "1.0.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-v5yCqQ/7okKoZZkBQUAfTsQ3sVJtXdNfbPnI5cceppoxEVLYA3k+VtV2omkeo8MS94JCy4fSiUwlRBAwCVRPUA==",
           "requires": {
             "graceful-fs": "^4.1.2"
           }
         },
         "read-installed": {
           "version": "4.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-/5uLZ/GH0eTCm5/rMfayI6zRkGc=",
           "requires": {
             "debuglog": "^1.0.1",
             "graceful-fs": "^4.1.2",
@@ -3987,7 +4301,8 @@
         },
         "read-package-json": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-dAiqGtVc/q5doFz6096CcnXhpYk0ZN8dEKVkGLU0CsASt8SrgF6SF7OTKAYubfvFhWaqofl+Y8HK19GR8jwW+A==",
           "requires": {
             "glob": "^7.1.1",
             "graceful-fs": "^4.1.2",
@@ -3998,7 +4313,8 @@
         },
         "read-package-tree": {
           "version": "5.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mLUDsD5JVtlZxjSlPPx1RETkNjjvQYuweKwNVt1Sn8kP5Jh44pvYuUHCp6xSVDZWbNxVxG5lyZJ921aJH61sTw==",
           "requires": {
             "read-package-json": "^2.0.0",
             "readdir-scoped-modules": "^1.0.0",
@@ -4007,7 +4323,8 @@
         },
         "readable-stream": {
           "version": "3.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -4016,7 +4333,8 @@
         },
         "readdir-scoped-modules": {
           "version": "1.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==",
           "requires": {
             "debuglog": "^1.0.1",
             "dezalgo": "^1.0.0",
@@ -4026,7 +4344,8 @@
         },
         "registry-auth-token": {
           "version": "3.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-4LM6Fw8eBQdwMYcES4yTnn2TqIasbXuwDx3um+QRs7S55aMKCBKBxvPXl2RiUjHwuJLTyYfxSpmfSAjQpcuP+A==",
           "requires": {
             "rc": "^1.1.6",
             "safe-buffer": "^5.0.1"
@@ -4034,14 +4353,16 @@
         },
         "registry-url": {
           "version": "3.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
           "requires": {
             "rc": "^1.0.1"
           }
         },
         "request": {
           "version": "2.88.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
           "requires": {
             "aws-sign2": "~0.7.0",
             "aws4": "^1.8.0",
@@ -4067,96 +4388,115 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I="
         },
         "require-main-filename": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg=="
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
         },
         "rimraf": {
           "version": "2.7.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
           "requires": {
             "glob": "^7.1.3"
           }
         },
         "run-queue": {
           "version": "1.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-6Eg5bwV9Ij8kOGkkYY4laUFh7Ec=",
           "requires": {
             "aproba": "^1.1.1"
           },
           "dependencies": {
             "aproba": {
               "version": "1.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
             }
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "semver": {
           "version": "5.7.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
         },
         "semver-diff": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
           "requires": {
             "semver": "^5.0.3"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "sha": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DOYnM37cNsLNSGIG/zZWch5CKIRNoLdYUQTQlcgkRkoYIUwDYjqDyye16YcDZg/OPdcbUgTKMjc4SY6TB7ZAPw==",
           "requires": {
             "graceful-fs": "^4.1.2"
           }
         },
         "shebang-command": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
           "requires": {
             "shebang-regex": "^1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
         },
         "smart-buffer": {
           "version": "4.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw=="
         },
         "socks": {
           "version": "2.3.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-o5t52PCNtVdiOvzMry7wU4aOqYWL0PeCXRWBEiJow4/i/wr+wpsJQ9awEu1EonLIqsfGd5qSgDdxEOvCdmBEpA==",
           "requires": {
             "ip": "1.1.5",
             "smart-buffer": "^4.1.0"
@@ -4164,7 +4504,8 @@
         },
         "socks-proxy-agent": {
           "version": "4.0.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-NT6syHhI9LmuEMSK6Kd2V7gNv5KFZoLE7V5udWmn0de+3Mkj3UMA/AJPLyeNUVmElCurSHtUdM3ETpR3z770Wg==",
           "requires": {
             "agent-base": "~4.2.1",
             "socks": "~2.3.2"
@@ -4172,7 +4513,8 @@
           "dependencies": {
             "agent-base": {
               "version": "4.2.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
               "requires": {
                 "es6-promisify": "^5.0.0"
               }
@@ -4181,11 +4523,13 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-fWMfS9OnmKJK8d/8+/6DM3pd9fw="
         },
         "sorted-union-stream": {
           "version": "2.1.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-x3lMfgd4gAUv9xqNSi27Sppjisc=",
           "requires": {
             "from2": "^1.3.0",
             "stream-iterate": "^1.1.0"
@@ -4193,7 +4537,8 @@
           "dependencies": {
             "from2": {
               "version": "1.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-iEE7qqX5pZfP3pIh2GmGzTwGHf0=",
               "requires": {
                 "inherits": "~2.0.1",
                 "readable-stream": "~1.1.10"
@@ -4201,11 +4546,13 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
             },
             "readable-stream": {
               "version": "1.1.14",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.1",
@@ -4215,13 +4562,15 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
           "requires": {
             "spdx-expression-parse": "^3.0.0",
             "spdx-license-ids": "^3.0.0"
@@ -4229,11 +4578,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg=="
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
           "requires": {
             "spdx-exceptions": "^2.1.0",
             "spdx-license-ids": "^3.0.0"
@@ -4241,15 +4592,18 @@
         },
         "spdx-license-ids": {
           "version": "3.0.5",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q=="
         },
         "split-on-first": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw=="
         },
         "sshpk": {
           "version": "1.14.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
           "requires": {
             "asn1": "~0.2.3",
             "assert-plus": "^1.0.0",
@@ -4264,14 +4618,16 @@
         },
         "ssri": {
           "version": "6.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-3Wge10hNcT1Kur4PDFwEieXSCMCJs/7WvSACcrMYrNp+b8kDL1/0wJch5Ni2WrtwEa2IO8OsVfeKIciKCDx/QA==",
           "requires": {
             "figgy-pudding": "^3.5.1"
           }
         },
         "stream-each": {
           "version": "1.2.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-mc1dbFhGBxvTM3bIWmAAINbqiuAk9TATcfIQC8P+/+HJefgaiTlMn2dHvkX8qlI12KeYKSQ1Ua9RrIqrn1VPoA==",
           "requires": {
             "end-of-stream": "^1.1.0",
             "stream-shift": "^1.0.0"
@@ -4279,7 +4635,8 @@
         },
         "stream-iterate": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-K9fHcpbBcCpGSIuK1B95hl7s1OE=",
           "requires": {
             "readable-stream": "^2.1.5",
             "stream-shift": "^1.0.0"
@@ -4287,7 +4644,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4300,7 +4658,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -4309,15 +4668,18 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-ucczDHBChi9rFC3CdLvMWGbONUY="
         },
         "string-width": {
           "version": "2.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
           "requires": {
             "is-fullwidth-code-point": "^2.0.0",
             "strip-ansi": "^4.0.0"
@@ -4325,15 +4687,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "strip-ansi": {
               "version": "4.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
               "requires": {
                 "ansi-regex": "^3.0.0"
               }
@@ -4342,46 +4707,54 @@
         },
         "string_decoder": {
           "version": "1.3.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
           "requires": {
             "safe-buffer": "~5.2.0"
           },
           "dependencies": {
             "safe-buffer": {
               "version": "5.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
             }
           }
         },
         "stringify-package": {
           "version": "1.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-sa4DUQsYciMP1xhKWGuFM04fB0LG/9DlluZoSVywUMRNvzid6XucHK0/90xGxRoHrAaROrcHK1aPKaijCtSrhg=="
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "supports-color": {
           "version": "5.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
           "requires": {
             "has-flag": "^3.0.0"
           }
         },
         "tar": {
           "version": "4.4.13",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
           "requires": {
             "chownr": "^1.1.1",
             "fs-minipass": "^1.2.5",
@@ -4394,7 +4767,8 @@
           "dependencies": {
             "minipass": {
               "version": "2.9.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -4404,22 +4778,26 @@
         },
         "term-size": {
           "version": "1.2.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
           "requires": {
             "execa": "^0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
         },
         "through2": {
           "version": "2.0.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
           "requires": {
             "readable-stream": "^2.1.5",
             "xtend": "~4.0.1"
@@ -4427,7 +4805,8 @@
           "dependencies": {
             "readable-stream": {
               "version": "2.3.6",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
               "requires": {
                 "core-util-is": "~1.0.0",
                 "inherits": "~2.0.3",
@@ -4440,7 +4819,8 @@
             },
             "string_decoder": {
               "version": "1.1.1",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
               "requires": {
                 "safe-buffer": "~5.1.0"
               }
@@ -4449,15 +4829,18 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-MOQHpzllWxDCHHaDno30hhLfbouoYlOI8YlMNtvKe1zXbjEVhbcEovQxvZrPvtiYW630GQDoMMarCnjfyfHA+A=="
         },
         "tough-cookie": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
             "psl": "^1.1.24",
             "punycode": "^1.4.1"
@@ -4465,60 +4848,71 @@
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
           "requires": {
             "safe-buffer": "^5.0.1"
           }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-DqEOgDXo61uOREnwbaHHMGY7qoE="
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-8pzr8B31F5ErtY/5xOUP3o4zMg0="
         },
         "unique-filename": {
           "version": "1.1.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==",
           "requires": {
             "unique-slug": "^2.0.0"
           }
         },
         "unique-slug": {
           "version": "2.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-22Z258fMBimHj/GWCXx4hVrp9Ks=",
           "requires": {
             "imurmurhash": "^0.1.4"
           }
         },
         "unique-string": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
           "requires": {
             "crypto-random-string": "^1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
         },
         "update-notifier": {
           "version": "2.5.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
           "requires": {
             "boxen": "^1.2.1",
             "chalk": "^2.0.1",
@@ -4534,46 +4928,54 @@
         },
         "uri-js": {
           "version": "4.4.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-B0yRTzYdUCCn9n+F4+Gh4yIDtMQcaJsmYBDsTSG8g/OejKBodLQ2IHfN3bM7jUsRXndopT7OIXWdYqc1fjmV6g==",
           "requires": {
             "punycode": "^2.1.0"
           },
           "dependencies": {
             "punycode": {
               "version": "2.1.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
             }
           }
         },
         "url-parse-lax": {
           "version": "1.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
           "requires": {
             "prepend-http": "^1.0.1"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-p8IW0mdUUWljeztu3GypEZ4v+T8="
         },
         "util-promisify": {
           "version": "2.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-PCI2R2xNMsX/PEcAKt18E7moKlM=",
           "requires": {
             "object.getownpropertydescriptors": "^2.0.3"
           }
         },
         "uuid": {
           "version": "3.3.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
           "requires": {
             "spdx-correct": "^3.0.0",
             "spdx-expression-parse": "^3.0.0"
@@ -4581,14 +4983,16 @@
         },
         "validate-npm-package-name": {
           "version": "3.0.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
           "requires": {
             "builtins": "^1.0.3"
           }
         },
         "verror": {
           "version": "1.10.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
           "requires": {
             "assert-plus": "^1.0.0",
             "core-util-is": "1.0.2",
@@ -4597,32 +5001,37 @@
         },
         "wcwidth": {
           "version": "1.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha1-8LDc+RW8X/FSivrbLA4XtTLaL+g=",
           "requires": {
             "defaults": "^1.0.3"
           }
         },
         "which": {
           "version": "1.3.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
           "requires": {
             "isexe": "^2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho="
         },
         "wide-align": {
           "version": "1.1.2",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
           "requires": {
             "string-width": "^1.0.2"
           },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",
@@ -4633,21 +5042,24 @@
         },
         "widest-line": {
           "version": "2.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-Ba5m9/Fa4Xt9eb2ELXt77JxVDV8w7qQrH0zS/TWSJdLyAwQjWoOzpzj5lwVftDz6n/EOu3tNACS84v509qwnJA==",
           "requires": {
             "string-width": "^2.1.1"
           }
         },
         "worker-farm": {
           "version": "1.7.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-rvw3QTZc8lAxyVrqcSGVm5yP/IJ2UcB3U0graE3LCFoZ0Yn2x4EoVSqJKdB/T5M+FLcRPjz4TDacRf3OCfNUzw==",
           "requires": {
             "errno": "~0.1.7"
           }
         },
         "wrap-ansi": {
           "version": "5.1.0",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "requires": {
             "ansi-styles": "^3.2.0",
             "string-width": "^3.0.0",
@@ -4656,15 +5068,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -4673,7 +5088,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -4682,11 +5098,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "write-file-atomic": {
           "version": "2.4.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
           "requires": {
             "graceful-fs": "^4.1.11",
             "imurmurhash": "^0.1.4",
@@ -4695,23 +5113,28 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true
+          "resolved": false,
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         },
         "yargs": {
           "version": "14.2.3",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-ZbotRWhF+lkjijC/VhmOT9wSgyBQ7+zr13+YLkhfsSiTriYsMzkTUFP18pFhWwBeMa5gUc1MzbhrO6/VB7c9Xg==",
           "requires": {
             "cliui": "^5.0.0",
             "decamelize": "^1.2.0",
@@ -4728,22 +5151,26 @@
           "dependencies": {
             "ansi-regex": {
               "version": "4.1.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             },
             "find-up": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
               "requires": {
                 "locate-path": "^3.0.0"
               }
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
             },
             "locate-path": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
               "requires": {
                 "p-locate": "^3.0.0",
                 "path-exists": "^3.0.0"
@@ -4751,25 +5178,29 @@
             },
             "p-limit": {
               "version": "2.3.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==",
               "requires": {
                 "p-try": "^2.0.0"
               }
             },
             "p-locate": {
               "version": "3.0.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
               "requires": {
                 "p-limit": "^2.0.0"
               }
             },
             "p-try": {
               "version": "2.2.0",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
             },
             "string-width": {
               "version": "3.1.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
               "requires": {
                 "emoji-regex": "^7.0.1",
                 "is-fullwidth-code-point": "^2.0.0",
@@ -4778,7 +5209,8 @@
             },
             "strip-ansi": {
               "version": "5.2.0",
-              "bundled": true,
+              "resolved": false,
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
               "requires": {
                 "ansi-regex": "^4.1.0"
               }
@@ -4787,7 +5219,8 @@
         },
         "yargs-parser": {
           "version": "15.0.1",
-          "bundled": true,
+          "resolved": false,
+          "integrity": "sha512-0OAMV2mAZQrs3FkNpDQcBk1x5HXb8X4twADss4S0Iuk+2dGnLOE/fRHrsYm542GduMveyA77OF4wrNJuanRCWw==",
           "requires": {
             "camelcase": "^5.0.0",
             "decamelize": "^1.2.0"
@@ -4795,7 +5228,8 @@
           "dependencies": {
             "camelcase": {
               "version": "5.3.1",
-              "bundled": true
+              "resolved": false,
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
             }
           }
         }
@@ -4815,7 +5249,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ=="
     },
     "oauth-sign": {
       "version": "0.9.0",
@@ -4825,7 +5259,7 @@
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -4839,7 +5273,7 @@
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "requires": {
         "wrappy": "1"
       }
@@ -4864,7 +5298,7 @@
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
-      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
       "dev": true,
       "requires": {
         "minimist": "~0.0.1",
@@ -4874,7 +5308,7 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
           "dev": true
         }
       }
@@ -4882,13 +5316,13 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "integrity": "sha512-B5JU3cabzk8c67mRRd3ECmROafjYMXbuzlwtqdM8IbS8ktlTix8aFGb2bAGKrSRIlnfKwovGUUr72JUPyOb6kQ==",
       "dev": true
     },
     "os-locale": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
-      "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
+      "integrity": "sha512-PRT7ZORmwu2MEFt4/fv3Q+mEfN4zetKxufQrkShY2oGvUms9r8otu5HfdyIFHkYXjO7laNsoVGmM2MANfuTA8g==",
       "requires": {
         "lcid": "^1.0.0"
       }
@@ -4896,7 +5330,7 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g=="
     },
     "osenv": {
       "version": "0.1.5",
@@ -4917,7 +5351,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -4928,13 +5362,13 @@
     "path-to-regexp": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w=",
+      "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "prebuild-install": {
       "version": "6.1.2",
@@ -4972,7 +5406,7 @@
     "property-accessors": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/property-accessors/-/property-accessors-1.1.3.tgz",
-      "integrity": "sha1-Hd6EAkYxhlkJ7zBwM2VoDF+SixU=",
+      "integrity": "sha512-WQTVW7rn+k6wq8FyYVM15afyoB2loEdeIzd/o7+HEA5hMZcxvRf4Khie0fBM9wLP3EJotKhiH15kY7Dd4gc57g==",
       "requires": {
         "es6-weak-map": "^0.1.2",
         "mixto": "1.x"
@@ -5010,7 +5444,7 @@
     "q": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
-      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+      "integrity": "sha512-kV/CThkXo6xyFEZUugw/+pIOywXcDbFYgSct5cT3gqlbkBE1SJdwy6UQoZvodiWF/ckQLZyDE/Bu1M6gVu5lVw=="
     },
     "qs": {
       "version": "6.5.2",
@@ -5056,7 +5490,7 @@
     "read": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-      "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+      "integrity": "sha512-rSOKNYUmaxy0om1BNjMN4ezNT6VKK+2xF4GBhc81mkH7L60i6dp8qPYrkndNLT3QPphoII3maL9PVC9XmhHwVQ==",
       "requires": {
         "mute-stream": "~0.0.4"
       }
@@ -5064,7 +5498,7 @@
     "readable-stream": {
       "version": "1.1.14",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -5075,7 +5509,7 @@
     "rechoir": {
       "version": "0.6.2",
       "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
-      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "integrity": "sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==",
       "dev": true,
       "requires": {
         "resolve": "^1.1.6"
@@ -5145,7 +5579,7 @@
     "season": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/season/-/season-6.0.2.tgz",
-      "integrity": "sha1-naWPsd3SSCTXYhstxjpxI7UCF7Y=",
+      "integrity": "sha512-5eq1ZKvsIUTkefE/R6PhJyiDDaalPjmdhUPVMuOFh4Yz2n5pBl1COkzNlxQyI8BXEBEIu1nJeJqJPVD0c3vycQ==",
       "requires": {
         "cson-parser": "^1.3.0",
         "fs-plus": "^3.0.0",
@@ -5242,7 +5676,7 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw=="
     },
     "setprototypeof": {
       "version": "1.1.1",
@@ -5282,7 +5716,7 @@
     "sigmund": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/sigmund/-/sigmund-1.0.1.tgz",
-      "integrity": "sha1-P/IfGYytIXX587eBhT/ZTQ0ZtZA=",
+      "integrity": "sha512-fCvEXfh6NWpm+YSuY2bpXb/VIihqWA6hLsgboC+0nl71Q7N7o2eaCW8mJa/NLvQhs6jpd3VZV4UiUQlV6+lc8g==",
       "dev": true
     },
     "signal-exit": {
@@ -5330,7 +5764,7 @@
     "string-width": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "integrity": "sha512-0XsVpQLnVCXHJfyEs8tC0zpTVIr5PKKsQtkT29IwupnPTjtPmQ3xT/4yCREF9hYkV/3M3kzcUTSAZT6a6h81tw==",
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -5340,12 +5774,12 @@
     "string_decoder": {
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ=="
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -5353,7 +5787,7 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
     },
     "tar": {
       "version": "6.0.5",
@@ -5475,7 +5909,7 @@
     "tmp": {
       "version": "0.0.28",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.28.tgz",
-      "integrity": "sha1-Fyc1t/YU6nrzlmT6hM8N5OUV0SA=",
+      "integrity": "sha512-c2mmfiBmND6SOVxzogm1oda0OJ1HZVIk/5n26N59dDTh80MUeavpiCls4PGAdkX1PFkKokLpcf7prSjCeXLsJg==",
       "requires": {
         "os-tmpdir": "~1.0.1"
       }
@@ -5489,7 +5923,7 @@
     "touch": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/touch/-/touch-0.0.3.tgz",
-      "integrity": "sha1-Ua7z1ElXHU8oel2Hyci0kYGg2x0=",
+      "integrity": "sha512-/LQ54KM9rPf3rGXGo2UPQWx3ol242Zg6Whq27H5DEmZhCJo+pm9N5BzRGepO9vTVhYxpXJdcc1+3uaYt9NyeKg==",
       "requires": {
         "nopt": "~1.0.10"
       },
@@ -5497,7 +5931,7 @@
         "nopt": {
           "version": "1.0.10",
           "resolved": "https://registry.npmjs.org/nopt/-/nopt-1.0.10.tgz",
-          "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
+          "integrity": "sha512-NWmpvLSqUrgrAC9HCuxEvb+PSloHpqVu+FqcO4eeF2h5qYRhA7ev6KvelyQAKtegUbC6RypJnlEOhd8vloNKYg==",
           "requires": {
             "abbrev": "1"
           }
@@ -5516,12 +5950,12 @@
     "traverse": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.3.9.tgz",
-      "integrity": "sha1-cXuPIgzAu3tE5AUUwisui7xw2Lk="
+      "integrity": "sha512-iawgk0hLP3SxGKDfnDJf8wTz4p2qImnyihM5Hh/sGvQ3K37dPi/w8sRhdNIxYA1TwFwc5mDhIJq+O0RsvXBKdQ=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "requires": {
         "safe-buffer": "^5.0.1"
       }
@@ -5529,7 +5963,7 @@
     "tweetnacl": {
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+      "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA=="
     },
     "type": {
       "version": "1.2.0",
@@ -5579,7 +6013,7 @@
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw=",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
       "dev": true
     },
     "uri-js": {
@@ -5593,12 +6027,12 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "dev": true
     },
     "uuid": {
@@ -5609,13 +6043,13 @@
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw=",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "dev": true
     },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
       "requires": {
         "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
@@ -5625,7 +6059,7 @@
     "walkdir": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/walkdir/-/walkdir-0.0.7.tgz",
-      "integrity": "sha1-BNoCcKh6d4VAFzzb8KLbSZqNnik=",
+      "integrity": "sha512-onj2wLVXrMWx/Ptvb1fobwLsoU/Aah+WHzcdu1iUXDKaJX12HWQsTF/41TwUBSULvNf+EjYMXoKePPt3x8FcXA==",
       "dev": true
     },
     "which": {
@@ -5648,17 +6082,17 @@
     "window-size": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.4.tgz",
-      "integrity": "sha1-+OGqHuWlPsW/FR/6CXQqatdpeHY="
+      "integrity": "sha512-2thx4pB0cV3h+Bw7QmMXcEbdmOzv9t0HFplJH/Lz6yu60hXYy5RT8rUu+wlIreVxWsGN20mo+MHeCSfUpQBwPw=="
     },
     "wordwrap": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+      "integrity": "sha512-gvVzJFlPycKc5dZN4yPkP8w7Dc37BtP1yczEneOb4uq34pXZcvrtRTmWV8W+Ume+XCxKgbjM+nevkyFPMybd4Q=="
     },
     "wrap-ansi": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "integrity": "sha512-vAaEaDM946gbNpH5pLVNR+vX2ht6n0Bt3GXwVB1AuAqZosOvHNF3P7wDnh8KLkSqgUh0uh77le7Owgoz+Z9XBw==",
       "requires": {
         "string-width": "^1.0.1",
         "strip-ansi": "^3.0.1"
@@ -5667,17 +6101,17 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
     },
     "wrench": {
       "version": "1.5.9",
       "resolved": "https://registry.npmjs.org/wrench/-/wrench-1.5.9.tgz",
-      "integrity": "sha1-QRaRxjqbJTGxcAJnJ5veyiOyFCo="
+      "integrity": "sha512-QH+8W9n0UGDAxnRDOkQzG1N277GTaBgMDNdckluqnAY773njfs1gfo867IbMMbGjOZZof+zlRIUeQ9XN8VUHUQ=="
     },
     "xmlbuilder": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-0.4.3.tgz",
-      "integrity": "sha1-xGFLp04K0ZbmCcknLNnh3bKKilg="
+      "integrity": "sha512-t3QW+VdXvxcy214Wf5Mvb+38RPW6EUG1RpMjjtG+esbAFh+/50PdXz1iGywefNl70DW2ucNWTXBw5buTgzDWyw=="
     },
     "xmldom": {
       "version": "0.1.27",
@@ -5697,7 +6131,7 @@
     "yargs": {
       "version": "3.32.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
-      "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
+      "integrity": "sha512-ONJZiimStfZzhKamYvR/xvmgW3uEkAUFSP91y2caTEPhzF6uP2JfPiVZcq66b/YR0C3uitxSV7+T1x8p5bkmMg==",
       "requires": {
         "camelcase": "^2.0.1",
         "cliui": "^3.0.3",

--- a/src/apm-cli.coffee
+++ b/src/apm-cli.coffee
@@ -3,7 +3,6 @@ path = require 'path'
 
 _ = require 'underscore-plus'
 colors = require 'colors'
-npm = require 'npm'
 yargs = require 'yargs'
 wordwrap = require 'wordwrap'
 
@@ -144,11 +143,8 @@ getAtomVersion = (callback) ->
       callback(unknownVersion)
 
 getPythonVersion = (callback) ->
-  npmOptions =
-    userconfig: config.getUserConfigPath()
-    globalconfig: config.getGlobalConfigPath()
-  npm.load npmOptions, ->
-    python = npm.config.get('python') ? process.env.PYTHON
+  config.getSetting 'python', (python) ->
+    python ?= process.env.PYTHON
     if config.isWin32() and not python
       rootDir = process.env.SystemDrive ? 'C:\\'
       rootDir += '\\' unless rootDir[rootDir.length - 1] is '\\'

--- a/src/ci.coffee
+++ b/src/ci.coffee
@@ -51,19 +51,18 @@ class Ci extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
 
-    installOptions = {env, streaming: options.argv.verbose}
+    @addBuildEnvVars env, (env) =>
+      installOptions = {env, streaming: options.argv.verbose}
 
-    @fork @atomNpmPath, installArgs, installOptions, (args...) =>
-      @logCommandResults(callback, args...)
+      @fork @atomNpmPath, installArgs, installOptions, (args...) =>
+        @logCommandResults(callback, args...)
 
   run: (options) ->
     {callback} = options
     opts = @parseOptions(options.commandArgs)
 
     commands = []
-    commands.push (callback) => config.loadNpm (error, @npm) => callback(error)
     commands.push (cb) => @loadInstalledAtomMetadata(cb)
     commands.push (cb) => @installModules(opts, cb)
 

--- a/src/dedupe.coffee
+++ b/src/dedupe.coffee
@@ -48,12 +48,11 @@ class Dedupe extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
+    @addBuildEnvVars env, (env) =>
+      dedupeOptions = {env}
+      dedupeOptions.cwd = options.cwd if options.cwd
 
-    dedupeOptions = {env}
-    dedupeOptions.cwd = options.cwd if options.cwd
-
-    @fork(@atomNpmPath, dedupeArgs, dedupeOptions, callback)
+      @fork(@atomNpmPath, dedupeArgs, dedupeOptions, callback)
 
   createAtomDirectories: ->
     fs.makeTreeSync(@atomDirectory)

--- a/src/git.coffee
+++ b/src/git.coffee
@@ -1,7 +1,6 @@
 {spawn} = require 'child_process'
 path = require 'path'
 _ = require 'underscore-plus'
-npm = require 'npm'
 config = require './apm'
 fs = require './fs'
 
@@ -50,11 +49,8 @@ exports.addGitToEnv = (env) ->
   addGitBashToEnv(env)
 
 exports.getGitVersion = (callback) ->
-  npmOptions =
-    userconfig: config.getUserConfigPath()
-    globalconfig: config.getGlobalConfigPath()
-  npm.load npmOptions, ->
-    git = npm.config.get('git') ? 'git'
+  config.getSetting 'git', (git) ->
+    git ?= 'git'
     exports.addGitToEnv(process.env)
     spawned = spawn(git, ['--version'])
     outputChunks = []

--- a/src/install.coffee
+++ b/src/install.coffee
@@ -74,47 +74,46 @@ class Install extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
+    @addBuildEnvVars env, (env) =>
+      installOptions = {env}
+      installOptions.streaming = true if @verbose
 
-    installOptions = {env}
-    installOptions.streaming = true if @verbose
+      if installGlobally
+        installDirectory = temp.mkdirSync('apm-install-dir-')
+        nodeModulesDirectory = path.join(installDirectory, 'node_modules')
+        fs.makeTreeSync(nodeModulesDirectory)
+        installOptions.cwd = installDirectory
 
-    if installGlobally
-      installDirectory = temp.mkdirSync('apm-install-dir-')
-      nodeModulesDirectory = path.join(installDirectory, 'node_modules')
-      fs.makeTreeSync(nodeModulesDirectory)
-      installOptions.cwd = installDirectory
+      @fork @atomNpmPath, installArgs, installOptions, (code, stderr='', stdout='') =>
+        if code is 0
+          if installGlobally
+            commands = []
+            children = fs.readdirSync(nodeModulesDirectory)
+              .filter (dir) -> dir isnt ".bin"
+            assert.equal(children.length, 1, "Expected there to only be one child in node_modules")
+            child = children[0]
+            source = path.join(nodeModulesDirectory, child)
+            destination = path.join(@atomPackagesDirectory, child)
+            commands.push (next) -> fs.cp(source, destination, next)
+            commands.push (next) => @buildModuleCache(pack.name, next)
+            commands.push (next) => @warmCompileCache(pack.name, next)
 
-    @fork @atomNpmPath, installArgs, installOptions, (code, stderr='', stdout='') =>
-      if code is 0
-        if installGlobally
-          commands = []
-          children = fs.readdirSync(nodeModulesDirectory)
-            .filter (dir) -> dir isnt ".bin"
-          assert.equal(children.length, 1, "Expected there to only be one child in node_modules")
-          child = children[0]
-          source = path.join(nodeModulesDirectory, child)
-          destination = path.join(@atomPackagesDirectory, child)
-          commands.push (next) -> fs.cp(source, destination, next)
-          commands.push (next) => @buildModuleCache(pack.name, next)
-          commands.push (next) => @warmCompileCache(pack.name, next)
-
-          async.waterfall commands, (error) =>
-            if error?
-              @logFailure()
-            else
-              @logSuccess() unless options.argv.json
-            callback(error, {name: child, installPath: destination})
+            async.waterfall commands, (error) =>
+              if error?
+                @logFailure()
+              else
+                @logSuccess() unless options.argv.json
+              callback(error, {name: child, installPath: destination})
+          else
+            callback(null, {name: child, installPath: destination})
         else
-          callback(null, {name: child, installPath: destination})
-      else
-        if installGlobally
-          fs.removeSync(installDirectory)
-          @logFailure()
+          if installGlobally
+            fs.removeSync(installDirectory)
+            @logFailure()
 
-        error = "#{stdout}\n#{stderr}"
-        error = @getGitErrorMessage(pack) if error.indexOf('code ENOGIT') isnt -1
-        callback(error)
+          error = "#{stdout}\n#{stderr}"
+          error = @getGitErrorMessage(pack) if error.indexOf('code ENOGIT') isnt -1
+          callback(error)
 
   getGitErrorMessage: (pack) ->
     message = """
@@ -166,13 +165,12 @@ class Install extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
+    @addBuildEnvVars env, (env) =>
+      installOptions = {env}
+      installOptions.cwd = options.cwd if options.cwd
+      installOptions.streaming = true if @verbose
 
-    installOptions = {env}
-    installOptions.cwd = options.cwd if options.cwd
-    installOptions.streaming = true if @verbose
-
-    @fork(@atomNpmPath, installArgs, installOptions, callback)
+      @fork(@atomNpmPath, installArgs, installOptions, callback)
 
   # Request package information from the atom.io API for a given package name.
   #
@@ -376,15 +374,14 @@ class Install extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
+    @addBuildEnvVars env, (env) =>
+      buildOptions = {env}
+      buildOptions.streaming = true if @verbose
 
-    buildOptions = {env}
-    buildOptions.streaming = true if @verbose
+      fs.removeSync(path.resolve(__dirname, '..', 'native-module', 'build'))
 
-    fs.removeSync(path.resolve(__dirname, '..', 'native-module', 'build'))
-
-    @fork @atomNpmPath, buildArgs, buildOptions, (args...) =>
-      @logCommandResults(callback, args...)
+      @fork @atomNpmPath, buildArgs, buildOptions, (args...) =>
+        @logCommandResults(callback, args...)
 
   packageNamesFromPath: (filePath) ->
     filePath = path.resolve(filePath)
@@ -558,9 +555,8 @@ class Install extends Command
     @createAtomDirectories()
 
     if options.argv.check
-      config.loadNpm (error, @npm) =>
-        @loadInstalledAtomMetadata =>
-          @checkNativeBuildTools(callback)
+      @loadInstalledAtomMetadata =>
+        @checkNativeBuildTools(callback)
       return
 
     @verbose = options.argv.verbose
@@ -600,7 +596,6 @@ class Install extends Command
       packageNames.push('.') if packageNames.length is 0
 
     commands = []
-    commands.push (callback) => config.loadNpm (error, @npm) => callback(error)
     commands.push (callback) => @loadInstalledAtomMetadata -> callback()
     packageNames.forEach (packageName) ->
       commands.push (callback) -> installPackage(packageName, callback)

--- a/src/rebuild.coffee
+++ b/src/rebuild.coffee
@@ -41,20 +41,18 @@ class Rebuild extends Command
     fs.makeTreeSync(@atomDirectory)
 
     env = _.extend({}, process.env, {HOME: @atomNodeDirectory, RUSTUP_HOME: config.getRustupHomeDirPath()})
-    @addBuildEnvVars(env)
-
-    @fork(@atomNpmPath, rebuildArgs, {env}, callback)
+    @addBuildEnvVars env, (env) =>
+      @fork(@atomNpmPath, rebuildArgs, {env}, callback)
 
   run: (options) ->
     {callback} = options
     options = @parseOptions(options.commandArgs)
 
-    config.loadNpm (error, @npm) =>
-      @loadInstalledAtomMetadata =>
-        @forkNpmRebuild options, (code, stderr='') =>
-          if code is 0
-            @logSuccess()
-            callback()
-          else
-            @logFailure()
-            callback(stderr)
+    @loadInstalledAtomMetadata =>
+      @forkNpmRebuild options, (code, stderr='') =>
+        if code is 0
+          @logSuccess()
+          callback()
+        else
+          @logFailure()
+          callback(stderr)

--- a/src/request.coffee
+++ b/src/request.coffee
@@ -1,23 +1,19 @@
-npm = require 'npm'
 request = require 'request'
 
 config = require './apm'
 
-loadNpm = (callback) ->
-  npmOptions =
-    userconfig: config.getUserConfigPath()
-    globalconfig: config.getGlobalConfigPath()
-  npm.load(npmOptions, callback)
-
 configureRequest = (requestOptions, callback) ->
-  loadNpm ->
-    requestOptions.proxy ?= npm.config.get('https-proxy') or npm.config.get('proxy') or process.env.HTTPS_PROXY or process.env.HTTP_PROXY
-    requestOptions.strictSSL ?= npm.config.get('strict-ssl')
+  config.getSetting 'proxy', (proxy) ->
+    config.getSetting 'https-proxy', (httpsProxy) ->
+      config.getSetting 'strict-ssl', (strictSsl) ->
+        config.getSetting 'user-agent', (userAgent) ->
+          requestOptions.proxy ?= httpsProxy or proxy or process.env.HTTPS_PROXY or process.env.HTTP_PROXY
+          requestOptions.strictSSL ?= strictSsl
 
-    userAgent = npm.config.get('user-agent') ? "AtomApm/#{require('../package.json').version}"
-    requestOptions.headers ?= {}
-    requestOptions.headers['User-Agent'] ?= userAgent
-    callback()
+          userAgent = userAgent ? "AtomApm/#{require('../package.json').version}"
+          requestOptions.headers ?= {}
+          requestOptions.headers['User-Agent'] ?= userAgent
+          callback()
 
 module.exports =
   get: (requestOptions, callback) ->


### PR DESCRIPTION
### Description of the Change

Since npm@8 drops programmable APIs, this PR removes references to those APIs so `apm` can be upgraded to npm@8 and Node 16. Follow changes are made to make it happen:
- refactor all calls to get npm config to use `apm.getSetting` instead
- `getSetting` spawns `npm config get` to load config instead of using `npm.load` API
- `addBuildEnvVars` and `addProxyToEnv` are converted to asynchronous to support that

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

- another blocker to npm@8 will be removed and it will allow to upgrade to Node 16 and further

### Possible Drawbacks

- spawning a new `npm` process may have a performance impact compared to using npm API. However, this only impacts `apm` which shouldn't be noticeable to users.

### Verification Process

I verified the change by running tests and my own atom build from this fork https://github.com/bongnv/atom/blob/master/apm/package.json#L9

### Applicable Issues

Haven't noticed any issues yet.
